### PR TITLE
fix sklearn set_config(transform='pandas') interaction

### DIFF
--- a/elpigraph/src/PCA.py
+++ b/elpigraph/src/PCA.py
@@ -41,7 +41,7 @@ def PCA(data):
 
 def TruncPCA(X, n_components, algorithm="arpack"):
     svd = TruncatedSVD(algorithm=algorithm, n_components=n_components)
-    prcomp = svd.fit_transform(X)
+    prcomp = np.asarray(svd.fit_transform(X))
     s = svd.singular_values_
     Vt = svd.components_
     U = prcomp / s


### PR DESCRIPTION
I ran into a weird bug when using your code together with the global sklearn configuration for pandas output. Here's a minimal script to reproduce the interaction:

```python
import numpy as np
from sklearn import set_config

import elpigraph


def main():
    data = np.random.randn(100, 3)
    # No problems here
    _ = elpigraph.computeElasticPrincipalCircle(data, NumNodes=50)

    set_config(transform_output="pandas")

    # Global configuration leads sklearn estimators output pandas.DataFrame
    # instead of a np.array -> InvalidIndexError
    _ = elpigraph.computeElasticPrincipalCircle(data, NumNodes=50)


if __name__ == "__main__":
    main()
```

Wrapping the transform output of sklearn estimators in `np.asarray` solves the issue. Thanks for the nice algorithm :)